### PR TITLE
BF: Update pyproject.toml numpy dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ urls.documentation = "https://pages.github.com/psychopy/psychopy-crs"
 urls.repository = "https://github.com/psychopy/psychopy-crs"
 dependencies = [
   "pyserial",
-  "numpy",
+  "numpy < 1.24",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This bug is a bit convoluted, so bear with me as I try to explain it in full.

1) For some reason (I think it's because the plug-in install destination uses `~/.psychopy3`), when installing plug-ins in the PsychoPy GUI, existing packages are not recognized when `pip install` is checking the existence of dependencies. For example for `psychopy-crs` here, even though the standalone PsychoPy application has `numpy` and `pyserial` already, installing the plug-in `psychopy-crs` will install these two packages along with `psychopy_crs`.

2) This is normally fine although not ideal since there are two competing packages with the same name in the search path. But the latest version of `numpy` >= 1.24 has deprecated a class `typeDict`. 

3) This class is imported by some test functions inside the package `pytables`, which in turn is imported by `iohub.__init__`.

4) So the end result is that if one installs the `psychopy-crs` plug-in, a new version of `numpy` gets installed, preventing `tables` to be imported, and disabling `ioHub` functionality.

Ultimately the fix should be to check the existing packages in the standalone PsychoPy installation when trying to pip install plug-ins, but this BF is a temporary solution to prevent ioHub (more specifically, hdf5 data storage functionality) from getting disabled.